### PR TITLE
feat: 스터디 게시판 기능 구현 틀

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+DB_URL=jdbc:mysql://localhost:3306/certif
+DB_USERNAME=root
+DB_PASSWORD=lolpop0527@

--- a/build.gradle
+++ b/build.gradle
@@ -18,10 +18,13 @@ repositories {
 }
 
 dependencies {
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-mustache'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'mysql:mysql-connector-java:8.0.33'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/example/certif/controller/StudyPostController.java
+++ b/src/main/java/com/example/certif/controller/StudyPostController.java
@@ -1,0 +1,85 @@
+import com.example.certif.dto.StudyPostDto;
+import com.example.certif.dto.StudyPostResponseDto;
+import com.example.certif.dto.StudyPostUpdateDto;
+import com.example.certif.service.StudyPostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.graphql.GraphQlProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+// StudyPostController.java
+@RestController
+@RequestMapping("/api/study")
+@RequiredArgsConstructor
+
+public class StudyPostController {
+    @Autowired
+    private StudyPostService studyPostService;
+
+    // 1-1. 스터디 게시판 전체 글 조회 by 카테고리에서 기본 화면 (카테고리 번호=1)
+    @GetMapping("/default")
+    public ResponseEntity<List<StudyPostResponseDto>> defaultposts() {
+        // 서비스에 위임
+        List<StudyPostDto> dtos = studyPostService.getDefaultCategoryPosts(1);
+        // 결과 응답
+        return ResponseEntity.status(HttpStatus.OK).body(dtos);
+    }
+
+
+    // 1-2. 스터디 게시판 전체 글 조회 by 카테고리
+    @GetMapping("/category/{categoryId}")
+    public ResponseEntity<List<StudyPostResponseDto>> posts(@PathVariable Long categoryId){
+        // 서비스에 위임
+        List<StudyPostDto> dtos = studyPostService.getPostsByCategory(categoryId);
+        // 결과 응답
+        return ResponseEntity.status(HttpStatus.OK).body(dtos);
+    }
+
+
+    // 1-3. 특정 스터디 게시판 글 조회
+    @GetMapping("/{postId}")
+    public ResponseEntity<StudyPostResponseDto> getPost(@PathVariable Long postId) {
+        // 서비스에 위임
+        StudyPostResponseDto dto = studyPostService.findById(postId);
+        // 결과 응답
+        return ResponseEntity.status(HttpStatus.OK).body(dto);
+    }
+
+
+
+    //  2. 스터디 게시판 글 생성
+    @PostMapping
+    public ResponseEntity<StudyPostResponseDto> create(@RequestBody StudyPostDto dto,
+                                                       @AuthenticationPrincipal User user) {
+        // 서비스에 위임
+        StudyPostDto createdDto = studyPostService.create(dto, user);
+        // 결과 응답
+        return ResponseEntity.status(HttpStatus.OK).body(createdDto);
+    }
+
+
+    // 3. 스터디 게시판 글 수정
+    @PatchMapping("/{postId}")
+    public ResponseEntity<StudyPostResponseDto> update(@PathVariable Long postId,
+                                                       @RequestBody StudyPostUpdateDto dto,
+                                                       @AuthenticationPrincipal User user){
+        // 서비스에 위임
+        StudyPostResponseDto updatedDto = studyPostService.update(postId, dto, user);
+        // 결과 응답
+        return ResponseEntity.status(HttpStatus.OK).body(updatedDto);
+    }
+
+
+    // 4. 스터디 게시판 글 삭제
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deletePost(@PathVariable Long postId,
+                                                         @AuthenticationPrincipal User user) {
+        studyPostService.delete(postId, user); // 작성자 확인 포함
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+}

--- a/src/main/java/com/example/certif/dto/StudyPostDto.java
+++ b/src/main/java/com/example/certif/dto/StudyPostDto.java
@@ -1,0 +1,19 @@
+package com.example.certif.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+
+public class StudyPostDto {
+    private Long id;
+    private String title;
+    private String content;
+    private Long userId;
+    private Long categoryId;
+}

--- a/src/main/java/com/example/certif/dto/StudyPostResponseDto.java
+++ b/src/main/java/com/example/certif/dto/StudyPostResponseDto.java
@@ -1,0 +1,36 @@
+package com.example.certif.dto;
+
+import com.example.certif.entity.StudyPost;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+
+public class StudyPostResponseDto {
+    private Long postId;
+    private String title;
+    private String content;
+    private String category;
+    private LocalDateTime createdAt;
+    private Long user_id;
+
+    public static StudyPostResponseDto createStudyPostDto(StudyPost studyPost) {
+        return StudyPostResponseDto.builder()
+                .postId(studyPost.getId())
+                .title(studyPost.getTitle())
+                .content(studyPost.getContent())
+                .category(studyPost.getCategory().getName())
+                .createdAt(studyPost.getCreatedAt())
+                .user_id(studyPost.getUser().getId())
+                .build();
+    }
+
+}
+

--- a/src/main/java/com/example/certif/dto/StudyPostUpdateDto.java
+++ b/src/main/java/com/example/certif/dto/StudyPostUpdateDto.java
@@ -1,0 +1,19 @@
+package com.example.certif.dto;
+
+import com.example.certif.entity.StudyPost;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+
+public class StudyPostUpdateDto {
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/example/certif/entity/StudyPost.java
+++ b/src/main/java/com/example/certif/entity/StudyPost.java
@@ -1,0 +1,67 @@
+package com.example.certif.entity;
+
+import com.example.certif.dto.StudyPostDto;
+import com.example.certif.dto.StudyPostUpdateDto;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "study_post")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StudyPost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 200, nullable = false)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    // 사용자 외래키
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // 카테고리 외래키
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    public static StudyPost createStudyPost(StudyPostDto dto, User user, Category category) {
+        return StudyPost.builder()
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .user(user)
+                .category(category)
+                .build();
+    }
+
+    public void patch(StudyPostUpdateDto dto) {
+        if (dto.getTitle() != null && !dto.getTitle().isEmpty()) {
+            this.title = dto.getTitle();
+        }
+        if (dto.getContent() != null && !dto.getContent().isEmpty()) {
+            this.content = dto.getContent();
+        }
+    }
+}

--- a/src/main/java/com/example/certif/repository/StudyPostRepository.java
+++ b/src/main/java/com/example/certif/repository/StudyPostRepository.java
@@ -1,0 +1,16 @@
+package com.example.certif.repository;
+
+import com.example.certif.entity.StudyPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StudyPostRepository extends JpaRepository<StudyPost, Long> {
+
+    // 카테고리별 최신순 정렬
+    List<StudyPost> findByCategoryIdOrderByCreatedAtDesc(Long categoryId);
+
+    // 게시글 ID로 조회
+    Optional<StudyPost> findByPostId(Long postId);
+}

--- a/src/main/java/com/example/certif/service/StudyPostService.java
+++ b/src/main/java/com/example/certif/service/StudyPostService.java
@@ -1,0 +1,120 @@
+package com.example.certif.service;
+
+import com.example.certif.dto.StudyPostDto;
+import com.example.certif.dto.StudyPostResponseDto;
+import com.example.certif.dto.StudyPostUpdateDto;
+import com.example.certif.entity.StudyPost;
+import com.example.certif.repository.StudyPostRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.apache.catalina.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.nio.file.AccessDeniedException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StudyPostService {
+
+    @Autowired
+    private StudyPostRepository studyPostRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    // 1-1. 스터디 게시판 전체 글 조회 by 카테고리에서 기본 화면 (카테고리 번호=1)
+    public List<StudyPostResponseDto> getDefaultCategoryPosts() {
+        // 1. 글조회
+        List<StudyPost> posts = studyPostRepository.findByCategoryIdOrderByCreatedAtDesc(1);
+        // 2. 엔티티 -> DTO 변환
+        List<StudyPostResponseDto> dtos = new ArrayList<>();
+        for (int i = 0; i < posts.size(); i++) {
+            StudyPost p = posts.get(i);
+            StudyPostResponseDto dto = StudyPostResponseDto.createStudyPostDto(p);
+            dtos.add(dto);
+        }
+        // 3. 결과 반환
+        return dtos;
+    }
+
+
+    // 1-2. 스터디 게시판 전체 글 조회 by 카테고리
+    public List<StudyPostResponseDto> getPostsByCategory(Long categoryId) {
+        // 1. 글조회
+        List<StudyPost> posts = studyPostRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId);
+        // 2. 엔티티 -> DTO 변환
+        List<StudyPostResponseDto> dtos = new ArrayList<>();
+        for (int i = 0; i < posts.size(); i++) {
+            StudyPost p = posts.get(i);
+            StudyPostResponseDto dto = StudyPostResponseDto.createStudyPostDto(p);
+            dtos.add(dto);
+        }
+        // 3. 결과 반환
+        return dtos;
+    }
+
+
+    // 1-3. 특정 스터디 게시판 글 조회
+    public StudyPostResponseDto findById(Long postId) {
+        StudyPost post = studyPostRepository.findByPostId(postId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다. postId=" + postId));
+        return StudyPostResponseDto.createStudyPostDto(post);
+    }
+   
+
+    // 2. 스터디 게시판 글 생성
+    @Transactional
+    public StudyPostResponseDto create(StudyPostDto dto, User user) {
+        // 1. 카테고리 조회
+        Category category = categoryRepository.findById(dto.getCategoryId())
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 카테고리"));
+        // 2. 게시판 글 엔티티 생성
+        StudyPost studypost = StudyPost.createStudyPost(dto, user, category);
+        // 3. 저장
+        StudyPost created = studyPostRepository.save(studypost);
+        // 4. 반환
+        return StudyPostResponseDto.createStudyPostDto(created);
+    }
+
+
+    // 3. 스터디 게시판 글 수정
+    @Transactional
+    public StudyPostResponseDto update(Long postId, StudyPostUpdateDto dto, User user) {
+        // 1. 게시판 글 조회 및 예외 발생
+        StudyPost target = studyPostRepository.findByPostId(postId)
+                .orElseThrow(() -> new IllegalArgumentException("스터디 게시판 글 수정 실패!" + "대상 게시판 글이 없습니다."));
+        // 2. 권한 체크 - 로그인한 사용자와 게시글 작성자가 같은지 확인
+        if (!target.getUser().getId().equals(user.getId())) {
+            throw new AccessDeniedException("수정 권한이 없습니다.");
+        }
+        // 3. 게시판 글 수정
+        target.patch(dto);
+        // 4. DB로 갱신
+        StudyPost updated = studyPostRepository.save(target);
+        // 5. 게시판 글 엔티티를 DTO로 변환 및 반환
+        return StudyPostResponseDto.createStudyPostDto(updated);
+    }
+
+
+    // 4. 스터디 게시판 글 삭제
+    @Transactional
+    public void delete(Long postId) {
+        // 1. 게시판 글 조회 및 예외 발생
+        StudyPost target = studyPostRepository.findByPostId(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시판 글 삭제 실패! " +
+                        "대상이 없습니다."));
+        // 2. 삭제 권한 확인
+        if (!target.getUser().getId().equals(user.getId())) {
+            throw new AccessDeniedException("삭제 권한이 없습니다.");
+        }
+        // 3. 게시판 글 삭제
+        studyPostRepository.delete(target);
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=certif
+
+spring.datasource.url=jdbc:mysql://localhost:3306/certif
+spring.datasource.username=root
+spring.datasource.password=lolpop0527@
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true


### PR DESCRIPTION
🔘 요약
스터디 게시판 글 crud 기능 구현(오류 고침 x + user, category 부분이랑 연결 필요)

🔎 작업 내용
스터디 게시판 글 기능에서 
1-1. 스터디 게시판 전체 글 조회 by 카테고리에서 기본 화면 (카테고리 번호=1)
1-2. 스터디 게시판 전체 글 조회 by 카테고리
1-3. 특정 스터디 게시판 글 조회
2. 스터디 게시판 글 생성
3. 스터디 게시판 글 수정
4. 스터디 게시판 글 삭제
기능 전반적인 틀 잡아둠 -  사소한 오류 아직 다 안 고침 + user, category 부분이랑 연결 필요

🔧 앞으로의 과제
오류 고치기
user 부분이랑 연결
category랑 연결
상태 및 예외 처리 더 구체적으로 